### PR TITLE
consistently spell ruby with a lower case "r"

### DIFF
--- a/lang/en-US/display_guide_vocabulary_w3c.json
+++ b/lang/en-US/display_guide_vocabulary_w3c.json
@@ -316,8 +316,8 @@
             "descriptive": "Page breaks included from the original print source"
         },
         "additional-accessibility-information-ruby-annotations": {
-            "compact": "Some Ruby annotations",
-            "descriptive": "Some Ruby annotations"
+            "compact": "Some ruby annotations",
+            "descriptive": "Some ruby annotations"
         },
         "additional-accessibility-information-sign-language": {
             "compact": "Sign language",


### PR DESCRIPTION
en-US version only, letting localisation organisations decide what is best for theire language and context.

This came from the raised issue [Ruby annotation case inconsistency #735](https://github.com/w3c/publ-a11y/issues/735) and after Looking at [https://www.w3.org/TR/ruby/](https://www.w3.org/TR/ruby/) where lowercase is consistently used.